### PR TITLE
Fix/withdraw buffer flow

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -153,8 +153,7 @@ sequenceDiagram
     Strategy-->>Vault: Return Balance
     alt Sufficient Balance
         Vault->>Strategy: Withdraw Funds
-        Strategy-->>Vault: Transfer Funds
-        Vault->>Asset: Transfer to User
+        Strategy-->>Asset: Transfer Funds
         Asset-->>User: Funds Received
     else Insufficient Balance
         Vault-->>User: Revert Transaction

--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -216,7 +216,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
             revert ExceededMaxWithdraw(owner, assets, maxAssets);
         }
         shares = previewWithdraw(assets);
-        _withdraw(asset(), _msgSender(), receiver, owner, assets, shares);
+        _withdraw(_msgSender(), receiver, owner, assets, shares);
     }
 
     /**
@@ -240,7 +240,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
             revert ExceededMaxRedeem(owner, shares, maxShares);
         }
         assets = previewRedeem(shares);
-        _withdraw(asset(), _msgSender(), receiver, owner, assets, shares);
+        _withdraw(_msgSender(), receiver, owner, assets, shares);
     }
 
     //// 4626-MAX ////
@@ -361,14 +361,13 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
 
     /**
      * @notice Internal function to handle withdrawals.
-     * @param asset_ The address of the asset.
      * @param caller The address of the caller.
      * @param receiver The address of the receiver.
      * @param owner The address of the owner.
      * @param assets The amount of assets to withdraw.
      * @param shares The equivalent amount of shares.
      */
-    function _withdraw(address asset_, address caller, address receiver, address owner, uint256 assets, uint256 shares)
+    function _withdraw(address caller, address receiver, address owner, uint256 assets, uint256 shares)
         internal
         virtual
     {
@@ -378,9 +377,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
             _spendAllowance(owner, caller, shares);
         }
 
-        IStrategy(vaultStorage.buffer).withdraw(assets, address(this), address(this));
-
-        SafeERC20.safeTransfer(IERC20(asset_), receiver, assets);
+        IStrategy(vaultStorage.buffer).withdraw(assets, receiver, address(this));
 
         _burn(owner, shares);
         emit Withdraw(caller, receiver, owner, assets, shares);

--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -400,11 +400,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         returns (uint256, uint256)
     {
         uint256 assets = shares.mulDiv(totalAssets() + 1, totalSupply() + 10 ** 0, rounding);
-<<<<<<< HEAD
         uint256 baseAssets = _convertBaseToAsset(asset_, assets);
-=======
-        uint256 baseAssets = _convertAssetToBase(asset_, assets);
->>>>>>> b9f401a (Moves Vault logic to abstract base contract)
         return (assets, baseAssets);
     }
 
@@ -439,7 +435,6 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     }
 
     /**
-<<<<<<< HEAD
      * @notice Internal function to convert base denominated amount to asset value.
      * @param asset_ The address of the asset.
      * @param assets The amount of the asset.
@@ -452,8 +447,6 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     }
 
     /**
-=======
->>>>>>> b9f401a (Moves Vault logic to abstract base contract)
      * @notice Internal function to get the vault storage.
      * @return $ The vault storage.
      */
@@ -555,13 +548,6 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         if (provider() == address(0)) {
             revert ProviderNotSet();
         }
-<<<<<<< HEAD
-
-=======
-        if (buffer() == address(0)) {
-            revert BufferNotSet();
-        }
->>>>>>> b9f401a (Moves Vault logic to abstract base contract)
         vaultStorage.paused = paused_;
         emit Pause(paused_);
     }

--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -400,7 +400,11 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         returns (uint256, uint256)
     {
         uint256 assets = shares.mulDiv(totalAssets() + 1, totalSupply() + 10 ** 0, rounding);
+<<<<<<< HEAD
         uint256 baseAssets = _convertBaseToAsset(asset_, assets);
+=======
+        uint256 baseAssets = _convertAssetToBase(asset_, assets);
+>>>>>>> b9f401a (Moves Vault logic to abstract base contract)
         return (assets, baseAssets);
     }
 
@@ -435,6 +439,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     }
 
     /**
+<<<<<<< HEAD
      * @notice Internal function to convert base denominated amount to asset value.
      * @param asset_ The address of the asset.
      * @param assets The amount of the asset.
@@ -447,6 +452,8 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     }
 
     /**
+=======
+>>>>>>> b9f401a (Moves Vault logic to abstract base contract)
      * @notice Internal function to get the vault storage.
      * @return $ The vault storage.
      */
@@ -548,7 +555,13 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         if (provider() == address(0)) {
             revert ProviderNotSet();
         }
+<<<<<<< HEAD
 
+=======
+        if (buffer() == address(0)) {
+            revert BufferNotSet();
+        }
+>>>>>>> b9f401a (Moves Vault logic to abstract base contract)
         vaultStorage.paused = paused_;
         emit Pause(paused_);
     }

--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -548,6 +548,10 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         if (provider() == address(0)) {
             revert ProviderNotSet();
         }
+<<<<<<< HEAD
+=======
+
+>>>>>>> e3a2fc5 (Allow Strategy to not use buffer)
         vaultStorage.paused = paused_;
         emit Pause(paused_);
     }

--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -545,10 +545,6 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         if (provider() == address(0)) {
             revert ProviderNotSet();
         }
-<<<<<<< HEAD
-=======
-
->>>>>>> e3a2fc5 (Allow Strategy to not use buffer)
         vaultStorage.paused = paused_;
         emit Pause(paused_);
     }

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -100,8 +100,9 @@ contract Strategy is BaseVault {
      * @param shares The equivalent amount of shares.
      * @dev The _withdraw function for strategies is permissioned by the allocator vault ALLOCATOR_ROLE
      */
-    function _withdraw(address asset_, address caller, address receiver, address owner, uint256 assets, uint256 shares)
+    function _withdraw(address caller, address receiver, address owner, uint256 assets, uint256 shares)
         internal
+        override
         onlyRole(ALLOCATOR_ROLE)
     {
         VaultStorage storage vaultStorage = _getVaultStorage();
@@ -110,8 +111,7 @@ contract Strategy is BaseVault {
             _spendAllowance(owner, caller, shares);
         }
 
-        IStrategy(vaultStorage.buffer).withdraw(assets, address(this), address(this));
-        SafeERC20.safeTransfer(IERC20(asset_), receiver, assets);
+        IStrategy(vaultStorage.buffer).withdraw(assets, receiver, address(this));
 
         _burn(owner, shares);
         emit Withdraw(caller, receiver, owner, assets, shares);

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -86,6 +86,7 @@ contract Strategy is BaseVault {
         vaultStorage.totalAssets += baseAssets;
 
         SafeERC20.safeTransferFrom(IERC20(asset_), caller, address(this), assets);
+
         _mint(receiver, shares);
         emit Deposit(caller, receiver, assets, shares);
     }

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -93,7 +93,6 @@ contract Strategy is BaseVault {
 
     /**
      * @notice Internal function to handle withdrawals.
-     * @param asset_ The address of the asset.
      * @param caller The address of the caller.
      * @param receiver The address of the receiver.
      * @param owner The address of the owner.
@@ -103,7 +102,6 @@ contract Strategy is BaseVault {
      */
     function _withdraw(address asset_, address caller, address receiver, address owner, uint256 assets, uint256 shares)
         internal
-        override
         onlyRole(ALLOCATOR_ROLE)
     {
         VaultStorage storage vaultStorage = _getVaultStorage();

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -86,7 +86,6 @@ contract Strategy is BaseVault {
         vaultStorage.totalAssets += baseAssets;
 
         SafeERC20.safeTransferFrom(IERC20(asset_), caller, address(this), assets);
-
         _mint(receiver, shares);
         emit Deposit(caller, receiver, assets, shares);
     }

--- a/src/interface/IProvider.sol
+++ b/src/interface/IProvider.sol
@@ -3,5 +3,4 @@ pragma solidity ^0.8.24;
 
 interface IProvider {
     function getRate(address asset) external view returns (uint256);
-    function otherAssets(address vault, address strategy) external view returns (uint256 assets);
 }

--- a/src/module/Provider.sol
+++ b/src/module/Provider.sol
@@ -37,29 +37,6 @@ contract Provider is IProvider {
 
         revert UnsupportedAsset(asset);
     }
-
-    function otherAssets(address vault, address strategy) public view returns (uint256 assets) {
-        if (strategy == MC.YNETH) {
-            (uint256[] memory withdrawalIndexes, WithdrawalRequest[] memory requests) =
-                IynETHwm(MC.YNETH_WM).withdrawalRequestsForOwner(vault);
-
-            uint256 length = withdrawalIndexes.length;
-            if (length == 0) return 0;
-
-            uint256 ynethRate = IERC4626(MC.YNETH).previewRedeem(1e18);
-            for (uint256 i = 0; i < length; i++) {
-                if (!requests[i].processed) {
-                    assets += requests[i].amount * ynethRate / 1e18;
-                }
-            }
-        } else if (strategy == MC.YNLSDE) {
-            // TODO
-            assets = 0;
-        }
-
-        // if strategy not handled, return 0 for other assets.
-        assets = 0;
-    }
 }
 
 interface IStETH {


### PR DESCRIPTION
This updates the _withdraw function to send the underlying asset directly to the user, instead of hoping back to vault then to user. This cuts the gas cost to withdraw by 1/2. 

The funds are now transfered from the buffer directly to the receiver. This is how the vault looked before:

```mermaid
sequenceDiagram
    participant User
    participant Vault as Vault Contract
    participant Strategy as Buffer
    participant Asset as Asset Contract

    User->>Vault: Request Withdrawal
    activate Vault
    Vault->>Strategy: Check Strategy Balance
    Strategy-->>Vault: Return Balance
    alt Sufficient Balance
        Vault->>Strategy: Withdraw Funds
        Strategy-->>Vault: Transfer Funds
        Vault->>Asset: Transfer to User
        Asset-->>User: Funds Received
    else Insufficient Balance
        Vault-->>User: Revert Transaction
    end
    deactivate Vault
```

But it has change to:

```mermaid
sequenceDiagram
    participant User
    participant Vault as Vault Contract
    participant Strategy as Buffer
    participant Asset as Asset Contract

    User->>Vault: Request Withdrawal
    activate Vault
    Vault->>Strategy: Check Strategy Balance
    Strategy-->>Vault: Return Balance
    alt Sufficient Balance
        Vault->>Strategy: Withdraw Funds
        Strategy-->>Asset: Transfer Funds
        Asset-->>User: Funds Received
    else Insufficient Balance
        Vault-->>User: Revert Transaction
    end
    deactivate Vault
```