### PR TITLE
fix maxDeposit limit bug

### DIFF
--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -104,14 +104,13 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
 
     /**
      * @notice Returns the maximum amount of assets that can be deposited by a given owner.
-     * @param owner The address of the owner.
      * @return uint256 The maximum amount of assets.
      */
-    function maxDeposit(address owner) public view virtual returns (uint256) {
+    function maxDeposit(address) public view virtual returns (uint256) {
         if (paused()) {
             return 0;
         }
-        return IERC20(asset()).balanceOf(owner);
+        return type(uint256).max;
     }
 
     /**

--- a/test/unit/deposit.t.sol
+++ b/test/unit/deposit.t.sol
@@ -186,7 +186,7 @@ contract VaultDepositUnitTest is Test, MainnetActors, Etches {
 
     function test_Vault_maxDeposit() public view {
         uint256 maxDeposit = vault.maxDeposit(alice);
-        assertEq(maxDeposit, weth.balanceOf(alice), "Max deposit does not match");
+        assertEq(maxDeposit, type(uint256).max, "Max deposit does not match");
     }
 
     function test_Vault_previewDepositAsset() public view {


### PR DESCRIPTION
Edit limit of the deposit to only be max uint, and not dependant of approval.