### PR TITLE
add custom validator

### DIFF
--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -616,7 +616,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         returnData = new bytes[](targetsLength);
 
         for (uint256 i = 0; i < targetsLength; i++) {
-            Guard.validateCall(targets[i], data[i]);
+            Guard.validateCall(targets[i], values[i], data[i]);
 
             (bool success, bytes memory returnData_) = targets[i].call{value: values[i]}(data[i]);
             if (!success) {

--- a/src/interface/IValidator.sol
+++ b/src/interface/IValidator.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.24;
+
+interface IValidator {
+    /// @notice Validates a transaction before execution
+    /// @param target The address the transaction will be sent to
+    /// @param value The amount of ETH (in wei) that will be sent with the transaction
+    /// @param data The calldata that will be sent with the transaction
+    /// @dev This function should revert if the transaction is invalid
+    /// @dev This function is called before executing a transaction
+    function validate(address target, uint256 value, bytes calldata data) external view;
+}

--- a/src/interface/IVault.sol
+++ b/src/interface/IVault.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {IERC4626} from "src/Common.sol";
+import {IValidator} from "src/interface/IValidator.sol";
 
 interface IVault is IERC4626 {
     struct VaultStorage {
@@ -37,6 +38,7 @@ interface IVault is IERC4626 {
     struct FunctionRule {
         bool isActive;
         ParamRule[] paramRules;
+        IValidator validator;
     }
 
     struct ProcessorStorage {

--- a/test/mainnet/curve.spec.sol
+++ b/test/mainnet/curve.spec.sol
@@ -12,6 +12,8 @@ import {AssertUtils} from "test/utils/AssertUtils.sol";
 import {ICurveRegistry} from "test/interface/external/curve/ICurveRegistry.sol";
 import {ICurvePool} from "test/interface/external/curve/ICurvePool.sol";
 import {IStETH} from "test/interface/external/lido/IStETH.sol";
+import {IValidator} from "src/interface/IValidator.sol";
+
 
 
 interface IynETH {
@@ -88,7 +90,8 @@ contract VaultMainnetCurveTest is Test, AssertUtils, MainnetActors {
 
             _vault.setProcessorRule(curvePools[i], exchange, IVault.FunctionRule({
                 isActive: true,
-                paramRules: exchangeRules
+                paramRules: exchangeRules,
+                validator: IValidator(address(0))
             }));
         }
         // Set approval rule to allow ethStethPool to spend stETH tokens from the vault

--- a/test/mainnet/helpers/SetupVault.sol
+++ b/test/mainnet/helpers/SetupVault.sol
@@ -9,6 +9,8 @@ import {MainnetActors} from "script/Actors.sol";
 import {MainnetContracts as MC} from "script/Contracts.sol";
 import {Etches} from "test/mainnet/helpers/Etches.sol";
 import {ynETHxVault} from "src/ynETHxVault.sol";
+import {IValidator} from "src/interface/IValidator.sol";
+
 
 contract SetupVault is Test, MainnetActors, Etches {
 
@@ -117,7 +119,7 @@ contract SetupVault is Test, MainnetActors, Etches {
 
         paramRules[1] = IVault.ParamRule({paramType: IVault.ParamType.ADDRESS, isArray: false, allowList: allowList});
 
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault_.setProcessorRule(contractAddress, funcSig, rule);
     }
@@ -138,7 +140,7 @@ contract SetupVault is Test, MainnetActors, Etches {
         paramRules[1] =
             IVault.ParamRule({paramType: IVault.ParamType.UINT256, isArray: false, allowList: new address[](0)});
 
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault_.setProcessorRule(contractAddress, funcSig, rule);
     }
@@ -148,7 +150,7 @@ contract SetupVault is Test, MainnetActors, Etches {
 
         IVault.ParamRule[] memory paramRules = new IVault.ParamRule[](0);
 
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault_.setProcessorRule(weth_, funcSig, rule);
     }    

--- a/test/mainnet/yneth.spec.sol
+++ b/test/mainnet/yneth.spec.sol
@@ -10,6 +10,8 @@ import {IVault} from "src/interface/IVault.sol";
 import {IERC20} from "src/Common.sol";
 import {IProvider} from "src/interface/IProvider.sol";
 import {AssertUtils} from "test/utils/AssertUtils.sol";
+import {IValidator} from "src/interface/IValidator.sol";
+
 
 interface IynETH {
     function depositETH(address receiver) external payable returns (uint256);
@@ -127,8 +129,7 @@ contract VaultMainnetYnETHTest is Test, AssertUtils, MainnetActors {
 
         paramRules[0] =
             IVault.ParamRule({paramType: IVault.ParamType.UINT256, isArray: false, allowList: new address[](0)});
-        
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault.setProcessorRule(MC.WETH, funcSig, rule);
     }
@@ -143,7 +144,7 @@ contract VaultMainnetYnETHTest is Test, AssertUtils, MainnetActors {
 
         paramRules[0] = IVault.ParamRule({paramType: IVault.ParamType.ADDRESS, isArray: false, allowList: allowList});
 
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault.setProcessorRule(MC.YNETH, funcSig, rule);
     }

--- a/test/unit/helpers/SetupVault.sol
+++ b/test/unit/helpers/SetupVault.sol
@@ -9,6 +9,7 @@ import {WETH9} from "test/unit/mocks/MockWETH.sol";
 import {Etches} from "test/unit/helpers/Etches.sol";
 import {MainnetActors} from "script/Actors.sol";
 import {MainnetContracts as MC} from "script/Contracts.sol";
+import {IValidator} from "src/interface/IValidator.sol";
 
 contract SetupVault is Test, Etches, MainnetActors {
     function setup() public returns (Vault vault, WETH9 weth) {
@@ -144,7 +145,8 @@ contract SetupVault is Test, Etches, MainnetActors {
 
         paramRules[1] = IVault.ParamRule({paramType: IVault.ParamType.ADDRESS, isArray: false, allowList: allowList});
 
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule =
+            IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault_.setProcessorRule(contractAddress, funcSig, rule);
     }
@@ -161,8 +163,8 @@ contract SetupVault is Test, Etches, MainnetActors {
 
         paramRules[1] =
             IVault.ParamRule({paramType: IVault.ParamType.UINT256, isArray: false, allowList: new address[](0)});
-
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule =
+            IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault_.setProcessorRule(contractAddress, funcSig, rule);
     }
@@ -172,7 +174,8 @@ contract SetupVault is Test, Etches, MainnetActors {
 
         IVault.ParamRule[] memory paramRules = new IVault.ParamRule[](0);
 
-        IVault.FunctionRule memory rule = IVault.FunctionRule({isActive: true, paramRules: paramRules});
+        IVault.FunctionRule memory rule =
+            IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
 
         vault_.setProcessorRule(weth_, funcSig, rule);
     }

--- a/test/unit/mocks/MockST_ETH.sol
+++ b/test/unit/mocks/MockST_ETH.sol
@@ -53,6 +53,10 @@ contract MockSTETH is IStETH, ERC20 {
         return submit(address(0));
     }
 
+    function deposit2() public payable returns (uint256) {
+        return deposit();
+    }
+
     receive() external payable {
         submit(address(0));
     }


### PR DESCRIPTION
adding custom validator that can override the ruleset when extra validation is needed.

Example: complex struct or array parsing, etc.


This way you can have best of both worlds. The rule based validation for general case which is just address whitelisting for now

and the custom logic validator a la Mellow (eg: https://github.com/mellow-finance/mellow-vaults/blob/main/src/interfaces/validators/IValidator.sol) only when needed.
