### PR TITLE
Update Strategy.sol

### DIFF
--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -16,6 +16,7 @@ contract Strategy is BaseVault {
         external
         initializer
     {
+require(admin != address(0), "Strategy: admin cannot be the zero address");
         __ERC20_init(name, symbol);
         __AccessControl_init();
         __ReentrancyGuard_init();


### PR DESCRIPTION
The provided Strategy contract does not explicitly incorporate a check to prevent passing a zero address (address(0)) as the admin during initialization. Without this check, the _grantRole(DEFAULT_ADMIN_ROLE, admin) call will succeed, granting the default admin role to the zero address, which is undesirable and can lead to governance issues.