### PR TITLE
fix issue YINE-c7850b7c-H01

### DIFF
--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -585,8 +585,15 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
         if (asset_ == address(0)) {
             revert ZeroAddress();
         }
+
         AssetStorage storage assetStorage = _getAssetStorage();
         uint256 index = assetStorage.list.length;
+
+        if (index == 0 && _getVaultStorage().countNativeAsset && decimals_ != 18) {
+            // if native asset is counted the primary asset should match the decimals count.
+            revert InvalidNativeAssetDecimals(decimals_);
+        }
+
         if (index > 0 && assetStorage.assets[asset_].index != 0) {
             revert DuplicateAsset(asset_);
         }
@@ -694,6 +701,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     function _computeTotalAssets() internal view virtual returns (uint256 totalBaseBalance) {
         VaultStorage storage vaultStorage = _getVaultStorage();
 
+        // Assumes native asset has same decimals as asset() (the base asset)
         totalBaseBalance = vaultStorage.countNativeAsset ? address(this).balance : 0;
 
         AssetStorage storage assetStorage = _getAssetStorage();

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -9,7 +9,7 @@ import {Math} from "./Common.sol";
 contract Vault is BaseVault {
     using Math for uint256;
 
-    string public constant VAULT_VERSION = "0.1.1";
+    string public constant VAULT_VERSION = "0.1.2";
 
     bytes32 public constant FEE_MANAGER_ROLE = keccak256("FEE_MANAGER_ROLE");
 

--- a/src/interface/IVault.sol
+++ b/src/interface/IVault.sol
@@ -75,6 +75,7 @@ interface IVault is IERC4626 {
     error DepositFailed();
     error AssetNotActive();
     error ExceedsMaxBasisPoints(uint256 value);
+    error InvalidNativeAssetDecimals(uint256 decimals);
 
     event DepositAsset(
         address indexed sender,

--- a/test/unit/admin.t.sol
+++ b/test/unit/admin.t.sol
@@ -12,6 +12,7 @@ import {MainnetContracts as MC} from "script/Contracts.sol";
 import {IVault} from "src/interface/IVault.sol";
 import {MockERC20} from "test/unit/mocks/MockERC20.sol";
 import {IAccessControl} from "src/Common.sol";
+import {MockERC20CustomDecimals} from "test/unit/mocks/MockERC20CustomDecimals.sol";
 
 contract VaultAdminUintTest is Test, MainnetActors, Etches {
     Vault public vaultImplementation;
@@ -143,5 +144,39 @@ contract VaultAdminUintTest is Test, MainnetActors, Etches {
         vm.prank(UNPAUSER);
         vm.expectRevert();
         vault.unpause();
+    }
+
+    function test_Vault_addAsset_firstAssetWithDifferentDecimals() public {
+        // Deploy implementation and proxy
+        Vault implementation = new Vault();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(implementation),
+            address(this),
+            abi.encodeWithSelector(
+                Vault.initialize.selector,
+                address(this),
+                "Test Vault",
+                "TV",
+                18,
+                0, // baseWithdrawalFee
+                true, // countNativeAsset
+                false // alwaysComputeTotalAssets
+            )
+        );
+        Vault newVault = Vault(payable(address(proxy)));
+
+        // Create mock asset with 6 decimals
+        MockERC20CustomDecimals sixDecimalAsset = new MockERC20CustomDecimals("Test", "TST", 6);
+
+        // Grant asset manager role
+        newVault.grantRole(newVault.ASSET_MANAGER_ROLE(), ASSET_MANAGER);
+
+        vm.startPrank(ASSET_MANAGER);
+
+        // Should revert when trying to add 6 decimal asset as first asset
+        vm.expectRevert(abi.encodeWithSelector(IVault.InvalidNativeAssetDecimals.selector, 6));
+        newVault.addAsset(address(sixDecimalAsset), true);
+
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
processAccounting currently assumes the native asset (eg. ETH or BNB) has the same number of decimals as .asset())

This enforces that in _addAsset.