### PR TITLE
fixed is-asset-withdrawable in BaseStrategy

### DIFF
--- a/src/strategy/BaseStrategy.sol
+++ b/src/strategy/BaseStrategy.sol
@@ -104,7 +104,7 @@ abstract contract BaseStrategy is BaseVault, IBaseStrategy {
      * @return maxAssets The maximum amount of assets.
      */
     function _maxWithdrawAsset(address asset_, address owner) internal view virtual returns (uint256 maxAssets) {
-        if (paused() || !_getAssetStorage().assets[asset_].active) {
+        if (paused() || !_getBaseStrategyStorage().isAssetWithdrawable[asset_]) {
             return 0;
         }
 
@@ -141,7 +141,7 @@ abstract contract BaseStrategy is BaseVault, IBaseStrategy {
      * @return maxShares The maximum amount of shares.
      */
     function _maxRedeemAsset(address asset_, address owner) internal view virtual returns (uint256 maxShares) {
-        if (paused() || !_getAssetStorage().assets[asset_].active) {
+        if (paused() || !_getBaseStrategyStorage().isAssetWithdrawable[asset_]) {
             return 0;
         }
 

--- a/test/unit/helpers/SetupStrategy.sol
+++ b/test/unit/helpers/SetupStrategy.sol
@@ -50,21 +50,12 @@ contract SetupStrategy is Test, Etches, MainnetActors {
 
         // Add assets: Base asset always first
         strategy.addAsset(MC.WETH, true);
-        strategy.addAsset(MC.BUFFER, false);
         strategy.addAsset(MC.STETH, true);
         strategy.addAsset(MC.WBTC, true);
 
-        // configure processor rules
-        setDepositRule(strategy, MC.BUFFER, address(strategy));
-        setWethDepositRule(strategy, MC.WETH);
-
-        setApprovalRule(strategy, MC.WETH, MC.BUFFER);
-        setApprovalRule(strategy, address(strategy), MC.YNETH);
-        setApprovalRule(strategy, address(strategy), MC.YNLSDE);
-
-        // add strategies
-
-        strategy.setBuffer(MC.BUFFER);
+        strategy.setAssetWithdrawable(MC.WETH, true);
+        strategy.setAssetWithdrawable(MC.STETH, true);
+        strategy.setAssetWithdrawable(MC.WBTC, true);
 
         // Set WBTC rate to 20 ETH
         MockProvider(MC.PROVIDER).setRate(MC.WBTC, 20e18);
@@ -72,53 +63,5 @@ contract SetupStrategy is Test, Etches, MainnetActors {
         MockProvider(MC.PROVIDER).setRate(MC.METH, 1.2e18);
 
         vm.stopPrank();
-    }
-
-    function setDepositRule(MockStrategy strategy_, address contractAddress, address receiver) internal {
-        bytes4 funcSig = bytes4(keccak256("deposit(uint256,address)"));
-
-        IVault.ParamRule[] memory paramRules = new IVault.ParamRule[](2);
-
-        paramRules[0] =
-            IVault.ParamRule({paramType: IVault.ParamType.UINT256, isArray: false, allowList: new address[](0)});
-
-        address[] memory allowList = new address[](1);
-        allowList[0] = receiver;
-
-        paramRules[1] = IVault.ParamRule({paramType: IVault.ParamType.ADDRESS, isArray: false, allowList: allowList});
-
-        IVault.FunctionRule memory rule =
-            IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
-
-        strategy_.setProcessorRule(contractAddress, funcSig, rule);
-    }
-
-    function setApprovalRule(MockStrategy strategy_, address contractAddress, address spender) internal {
-        bytes4 funcSig = bytes4(keccak256("approve(address,uint256)"));
-
-        IVault.ParamRule[] memory paramRules = new IVault.ParamRule[](2);
-
-        address[] memory allowList = new address[](1);
-        allowList[0] = spender;
-
-        paramRules[0] = IVault.ParamRule({paramType: IVault.ParamType.ADDRESS, isArray: false, allowList: allowList});
-
-        paramRules[1] =
-            IVault.ParamRule({paramType: IVault.ParamType.UINT256, isArray: false, allowList: new address[](0)});
-        IVault.FunctionRule memory rule =
-            IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
-
-        strategy_.setProcessorRule(contractAddress, funcSig, rule);
-    }
-
-    function setWethDepositRule(MockStrategy strategy_, address weth_) public {
-        bytes4 funcSig = bytes4(keccak256("deposit()"));
-
-        IVault.ParamRule[] memory paramRules = new IVault.ParamRule[](0);
-
-        IVault.FunctionRule memory rule =
-            IVault.FunctionRule({isActive: true, paramRules: paramRules, validator: IValidator(address(0))});
-
-        strategy_.setProcessorRule(weth_, funcSig, rule);
     }
 }

--- a/test/unit/strategy/admin.t.sol
+++ b/test/unit/strategy/admin.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {Test} from "lib/forge-std/src/Test.sol";
 import {MainnetContracts as MC} from "script/Contracts.sol";
-import {TransparentUpgradeableProxy} from "src/Common.sol";
+import {TransparentUpgradeableProxy, IAccessControl} from "src/Common.sol";
 import {Etches} from "test/unit/helpers/Etches.sol";
 import {WETH9} from "test/unit/mocks/MockWETH.sol";
 import {Math} from "src/Common.sol";
@@ -12,6 +12,8 @@ import {MockStrategy} from "test/unit/mocks/MockStrategy.sol";
 import {MockProvider} from "test/unit/mocks/MockProvider.sol";
 import {MainnetActors} from "script/Actors.sol";
 import {SetupStrategy} from "test/unit/helpers/SetupStrategy.sol";
+import {MockERC20CustomDecimals as MockERC20} from "test/unit/mocks/MockERC20CustomDecimals.sol";
+import {IVault} from "src/interface/IVault.sol";
 
 contract StrategAdminUnitTest is Test, Etches, MainnetActors {
     using Math for uint256;
@@ -21,6 +23,8 @@ contract StrategAdminUnitTest is Test, Etches, MainnetActors {
 
     address public alice = address(0x1);
     uint256 public constant INITIAL_BALANCE = 100_000 ether;
+
+    IERC20 public asset;
 
     function setUp() public {
         SetupStrategy setupStrategy = new SetupStrategy();
@@ -34,23 +38,156 @@ contract StrategAdminUnitTest is Test, Etches, MainnetActors {
         // Approve strategy to spend Alice's tokens
         vm.prank(alice);
         weth.approve(address(strategy), type(uint256).max);
+
+        asset = new MockERC20("Asset", "AST", 18);
     }
 
-    function test_Strategy_SetHasAllocator() public {
+    function test_Strategy_setHasAllocator() public {
         vm.prank(ALLOCATOR_MANAGER);
         strategy.setHasAllocator(true);
-        assertEq(strategy.getHasAllocator(), true, "Mock strategy should have allocators");
+        assertEq(strategy.getHasAllocator(), true);
+
+        vm.prank(ALLOCATOR_MANAGER);
+        strategy.setHasAllocator(false);
+        assertEq(strategy.getHasAllocator(), false);
     }
 
-    function test_Strategy_SetHasAllocator_RevertUnauthorized() public {
-        vm.prank(alice);
-        vm.expectRevert();
+    function test_Strategy_setHasAllocator_unauthorized() public {
+        bytes memory error = abi.encodeWithSelector(
+            IAccessControl.AccessControlUnauthorizedAccount.selector, UNAUTHORIZED, strategy.ALLOCATOR_MANAGER_ROLE()
+        );
+        vm.expectRevert(error);
+        vm.prank(UNAUTHORIZED);
         strategy.setHasAllocator(true);
     }
 
-    function test_Strategy_AddAsset() public {
+    function test_Strategy_setAssetWithdrawable() public {
         vm.prank(ASSET_MANAGER);
-        strategy.addAsset(MC.METH, true, true);
-        assertEq(strategy.getAssetWithdrawable(MC.METH), true, "METH should be withdrawable");
+        strategy.addAsset(address(asset), true);
+
+        assertEq(strategy.getAssetWithdrawable(address(asset)), false, "asset should not be withdrawable");
+
+        vm.prank(ASSET_MANAGER);
+        strategy.setAssetWithdrawable(address(asset), true);
+
+        assertEq(strategy.getAssetWithdrawable(address(asset)), true, "asset should be withdrawable");
+
+        vm.prank(ASSET_MANAGER);
+        strategy.setAssetWithdrawable(address(asset), false);
+
+        assertEq(strategy.getAssetWithdrawable(address(asset)), false, "asset should not be withdrawable");
+    }
+
+    function test_Strategy_setAssetWithdrawable_unauthorized() public {
+        bytes memory error = abi.encodeWithSelector(
+            IAccessControl.AccessControlUnauthorizedAccount.selector, UNAUTHORIZED, strategy.ASSET_MANAGER_ROLE()
+        );
+        vm.expectRevert(error);
+        vm.prank(UNAUTHORIZED);
+        strategy.setAssetWithdrawable(address(asset), true);
+    }
+
+    function test_Strategy_addAsset_Depositable_NotWithdrawable() public {
+        MockERC20 asset2 = new MockERC20("Mock Token 2", "MOCK2", 12);
+        vm.prank(ASSET_MANAGER);
+        strategy.addAsset(address(asset2), 12, true, false);
+
+        assertEq(strategy.getAsset(address(asset2)).active, true, "asset2 should be active");
+        assertEq(strategy.getAsset(address(asset2)).decimals, 12, "asset2 should have 10 decimals");
+        assertEq(strategy.getAssetWithdrawable(address(asset2)), false, "asset2 should not be withdrawable");
+
+        MockERC20 asset3 = new MockERC20("Mock Token 3", "MOCK3", 10);
+        vm.prank(ASSET_MANAGER);
+        strategy.addAsset(address(asset3), true);
+
+        assertEq(strategy.getAsset(address(asset3)).active, true, "asset2 should be active");
+        assertEq(strategy.getAsset(address(asset3)).decimals, 10, "asset2 should have 10 decimals");
+        assertEq(strategy.getAssetWithdrawable(address(asset3)), false, "asset2 should not be withdrawable");
+    }
+
+    function test_Strategy_addAsset_Depositable_Withdrawable() public {
+        vm.prank(ASSET_MANAGER);
+        strategy.addAsset(address(asset), true, true);
+
+        assertEq(strategy.getAsset(address(asset)).active, true);
+        assertEq(strategy.getAsset(address(asset)).decimals, 18, "asset should have 18 decimals");
+        assertEq(strategy.getAssetWithdrawable(address(asset)), true, "asset should not be withdrawable");
+    }
+
+    function test_Strategy_addAsset_NotDepositable_NotWithdrawable() public {
+        vm.prank(ASSET_MANAGER);
+        strategy.addAsset(address(asset), false);
+        assertEq(strategy.getAsset(address(asset)).active, false);
+        assertEq(strategy.getAsset(address(asset)).decimals, 18, "asset should have 18 decimals");
+        assertEq(strategy.getAssetWithdrawable(address(asset)), false, "asset should not be withdrawable");
+
+        MockERC20 asset2 = new MockERC20("Mock Token 2", "MOCK2", 12);
+        vm.prank(ASSET_MANAGER);
+        strategy.addAsset(address(asset2), 12, false, false);
+
+        assertEq(strategy.getAsset(address(asset2)).active, false, "asset2 should not be active");
+        assertEq(strategy.getAsset(address(asset2)).decimals, 12, "asset2 should have 10 decimals");
+        assertEq(strategy.getAssetWithdrawable(address(asset2)), false, "asset2 should not be withdrawable");
+
+        MockERC20 asset3 = new MockERC20("Mock Token 3", "MOCK3", 10);
+        vm.prank(ASSET_MANAGER);
+        strategy.addAsset(address(asset3), false);
+
+        assertEq(strategy.getAsset(address(asset3)).active, false, "asset2 should not be active");
+        assertEq(strategy.getAsset(address(asset3)).decimals, 10, "asset2 should have 10 decimals");
+        assertEq(strategy.getAssetWithdrawable(address(asset3)), false, "asset2 should not be withdrawable");
+    }
+
+    function test_Strategy_addAsset_NotDepositable_Withdrawable() public {
+        MockERC20 asset2 = new MockERC20("Mock Token 2", "MOCK2", 12);
+        vm.prank(ASSET_MANAGER);
+        strategy.addAsset(address(asset2), 12, false, true);
+
+        assertEq(strategy.getAsset(address(asset2)).active, false, "asset2 should not be active");
+        assertEq(strategy.getAsset(address(asset2)).decimals, 12, "asset2 should have 10 decimals");
+        assertEq(strategy.getAssetWithdrawable(address(asset2)), true, "asset2 should be withdrawable");
+    }
+
+    function test_Strategy_addAsset_nullAddress() public {
+        vm.prank(ASSET_MANAGER);
+        // call reverts when trying to get decimals from zero address
+        vm.expectRevert();
+        strategy.addAsset(address(0), true);
+
+        vm.prank(ASSET_MANAGER);
+        vm.expectRevert();
+        strategy.addAsset(address(0), 18, true, true);
+
+        vm.prank(ASSET_MANAGER);
+        vm.expectRevert();
+        strategy.addAsset(address(0), true, true);
+    }
+
+    function test_Strategy_addAsset_duplicateAddress() public {
+        vm.startPrank(ASSET_MANAGER);
+        strategy.addAsset(address(asset), 18, true, true);
+
+        vm.expectRevert(abi.encodeWithSelector(IVault.DuplicateAsset.selector, address(asset)));
+        strategy.addAsset(address(asset), 18, true, true);
+
+        vm.expectRevert(abi.encodeWithSelector(IVault.DuplicateAsset.selector, address(asset)));
+        strategy.addAsset(address(asset), true, true);
+    }
+
+    function test_Strategy_addAsset_unauthorized() public {
+        bytes memory error = abi.encodeWithSelector(
+            IAccessControl.AccessControlUnauthorizedAccount.selector, UNAUTHORIZED, strategy.ASSET_MANAGER_ROLE()
+        );
+        vm.expectRevert(error);
+        vm.prank(UNAUTHORIZED);
+        strategy.addAsset(address(asset), true);
+
+        vm.expectRevert(error);
+        vm.prank(UNAUTHORIZED);
+        strategy.addAsset(address(asset), 18, true, true);
+
+        vm.expectRevert(error);
+        vm.prank(UNAUTHORIZED);
+        strategy.addAsset(address(asset), true, true);
     }
 }

--- a/test/unit/strategy/views.t.sol
+++ b/test/unit/strategy/views.t.sol
@@ -50,21 +50,60 @@ contract StrategyViewsUnitTest is Test, Etches, MainnetActors {
 
     function test_Strategy_MaxRedeem() public {
         assertEq(strategy.maxRedeem(address(alice)), 0, "Alice should have max redeem of 0");
+        assertEq(strategy.maxRedeemAsset(MC.WETH, address(alice)), 0, "Alice should have max redeem of 0");
         vm.prank(alice);
         strategy.deposit(INITIAL_BALANCE, alice);
         assertEq(
             strategy.maxRedeem(address(alice)), INITIAL_BALANCE, "Alice should have max redeem of INITIAL_BALANCE WETH"
         );
+        assertEq(
+            strategy.maxRedeemAsset(MC.WETH, address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max redeem of INITIAL_BALANCE WETH"
+        );
     }
 
     function test_Stategy_MaxRedeem_Paused() public {
+        assertEq(strategy.maxRedeem(address(alice)), 0, "Alice should have max redeem of 0");
+        assertEq(strategy.maxRedeemAsset(MC.WETH, address(alice)), 0, "Alice should have max redeem of 0");
+        vm.prank(alice);
+        strategy.deposit(INITIAL_BALANCE, alice);
+        assertEq(
+            strategy.maxRedeem(address(alice)), INITIAL_BALANCE, "Alice should have max redeem of INITIAL_BALANCE WETH"
+        );
+        assertEq(
+            strategy.maxRedeemAsset(MC.WETH, address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max redeem of INITIAL_BALANCE WETH"
+        );
         vm.prank(PAUSER);
         strategy.pause();
-        assertEq(strategy.maxRedeem(address(alice)), 0, "Paused  should have max redeem of 0");
+        assertEq(strategy.maxRedeem(address(alice)), 0, "Paused should have max redeem of 0");
+        assertEq(strategy.maxRedeemAsset(MC.WETH, address(alice)), 0, "Paused should have max redeem of 0");
+    }
+
+    function test_Stategy_MaxRedeem_NotWithdrawable() public {
+        assertEq(strategy.maxRedeem(address(alice)), 0, "Alice should have max redeem of 0");
+        assertEq(strategy.maxRedeemAsset(MC.WETH, address(alice)), 0, "Alice should have max redeem of 0");
+        vm.prank(alice);
+        strategy.deposit(INITIAL_BALANCE, alice);
+        assertEq(
+            strategy.maxRedeem(address(alice)), INITIAL_BALANCE, "Alice should have max redeem of INITIAL_BALANCE WETH"
+        );
+        assertEq(
+            strategy.maxRedeemAsset(MC.WETH, address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max redeem of INITIAL_BALANCE WETH"
+        );
+        vm.prank(ASSET_MANAGER);
+        strategy.setAssetWithdrawable(MC.WETH, false);
+        assertEq(strategy.maxRedeem(address(alice)), 0, "Max redeem should be 0 when withdrawable false");
+        assertEq(strategy.maxRedeemAsset(MC.WETH, address(alice)), 0, "Paused should have max redeem of 0");
     }
 
     function test_Strategy_MaxWithdraw() public {
         assertEq(strategy.maxWithdraw(address(alice)), 0, "Alice should have max withdraw of 0");
+        assertEq(strategy.maxWithdrawAsset(MC.WETH, address(alice)), 0, "Alice should have max withdraw of 0");
         vm.prank(alice);
         strategy.deposit(INITIAL_BALANCE, alice);
         assertEq(
@@ -72,6 +111,53 @@ contract StrategyViewsUnitTest is Test, Etches, MainnetActors {
             INITIAL_BALANCE,
             "Alice should have max withdraw of INITIAL_BALANCE WETH"
         );
+        assertEq(
+            strategy.maxWithdrawAsset(MC.WETH, address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max withdraw of INITIAL_BALANCE WETH"
+        );
+    }
+
+    function test_Stategy_MaxWithdraw_Paused() public {
+        assertEq(strategy.maxWithdraw(address(alice)), 0, "Alice should have max withdraw of 0");
+        assertEq(strategy.maxWithdrawAsset(MC.WETH, address(alice)), 0, "Alice should have max withdraw of 0");
+        vm.prank(alice);
+        strategy.deposit(INITIAL_BALANCE, alice);
+        assertEq(
+            strategy.maxWithdraw(address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max withdraw of INITIAL_BALANCE WETH"
+        );
+        assertEq(
+            strategy.maxWithdrawAsset(MC.WETH, address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max withdraw of INITIAL_BALANCE WETH"
+        );
+        vm.prank(PAUSER);
+        strategy.pause();
+        assertEq(strategy.maxWithdraw(address(alice)), 0, "Paused should have max withdraw of 0");
+        assertEq(strategy.maxWithdrawAsset(MC.WETH, address(alice)), 0, "Paused should have max withdraw of 0");
+    }
+
+    function test_Stategy_MaxWithdraw_NotWithdrawable() public {
+        assertEq(strategy.maxWithdraw(address(alice)), 0, "Alice should have max withdraw of 0");
+        assertEq(strategy.maxWithdrawAsset(MC.WETH, address(alice)), 0, "Alice should have max withdraw of 0");
+        vm.prank(alice);
+        strategy.deposit(INITIAL_BALANCE, alice);
+        assertEq(
+            strategy.maxWithdraw(address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max withdraw of INITIAL_BALANCE WETH"
+        );
+        assertEq(
+            strategy.maxWithdrawAsset(MC.WETH, address(alice)),
+            INITIAL_BALANCE,
+            "Alice should have max withdraw of INITIAL_BALANCE WETH"
+        );
+        vm.prank(ASSET_MANAGER);
+        strategy.setAssetWithdrawable(MC.WETH, false);
+        assertEq(strategy.maxWithdraw(address(alice)), 0, "Max withdraw should be 0 when withdrawable false");
+        assertEq(strategy.maxWithdrawAsset(MC.WETH, address(alice)), 0, "Paused should have max withdraw of 0");
     }
 
     function test_Strategy_PreviewMintAsset() public view {

--- a/test/unit/strategy/withdraw.t.sol
+++ b/test/unit/strategy/withdraw.t.sol
@@ -2,19 +2,16 @@
 pragma solidity ^0.8.24;
 
 import {Test} from "lib/forge-std/src/Test.sol";
-import {MainnetContracts as MC} from "script/Contracts.sol";
-import {TransparentUpgradeableProxy} from "src/Common.sol";
 import {Etches} from "test/unit/helpers/Etches.sol";
 import {WETH9} from "test/unit/mocks/MockWETH.sol";
 import {Math} from "src/Common.sol";
-import {IERC20, IERC20Metadata} from "src/Common.sol";
+import {IERC20} from "src/Common.sol";
 import {MockStrategy} from "test/unit/mocks/MockStrategy.sol";
-import {MockProvider} from "test/unit/mocks/MockProvider.sol";
 import {MainnetActors} from "script/Actors.sol";
 import {SetupStrategy} from "test/unit/helpers/SetupStrategy.sol";
-import {FeeMath} from "src/module/FeeMath.sol";
+import {IVault} from "src/interface/IVault.sol";
 
-contract StrategWithdrawUnitTest is Test, Etches, MainnetActors {
+contract StrategyWithdrawUnitTest is Test, Etches, MainnetActors {
     using Math for uint256;
 
     MockStrategy public strategy;
@@ -194,6 +191,30 @@ contract StrategWithdrawUnitTest is Test, Etches, MainnetActors {
         assertEq(strategy.balanceOf(alice), shares - maxShares, "Receiver should have correct shares remaining");
     }
 
+    function test_Strategy_Withdrawable_Asset_Revert_NotWithdrawable(uint256 assets) public {
+        vm.assume(assets >= 1000 && assets <= 100_000 ether);
+        uint256 shares = depositIntoStrategy(address(weth), alice, assets);
+        // assert withdrawable assets are equal to shares when asset is withdrawable
+        assertEq(
+            strategy.maxWithdrawAsset(address(weth), alice), shares, "withdrawable Assets should be equal to assets"
+        );
+
+        // set asset to not withdrawable
+        vm.prank(ASSET_MANAGER);
+        strategy.setAssetWithdrawable(address(weth), false);
+
+        assertEq(
+            strategy.maxWithdrawAsset(address(weth), alice),
+            0,
+            "withdrawable Assets should be 0 after asset is set to not withdrawable"
+        );
+
+        vm.startPrank(alice);
+        // withdraw
+        vm.expectRevert(abi.encodeWithSelector(IVault.ExceededMaxWithdraw.selector, alice, shares, 0));
+        strategy.withdrawAsset(address(weth), shares, alice, alice);
+    }
+
     function test_Strategy_Redeem(uint256 assets) public {
         // Bound inputs to valid ranges
         vm.assume(assets >= 100000 && assets <= 100_000 ether);
@@ -216,5 +237,129 @@ contract StrategWithdrawUnitTest is Test, Etches, MainnetActors {
         assertApproxEqRel(redeemedAmount, convertedAssets, 1e14, "Redeemed amount should be total assets minus fee");
 
         assertEq(strategy.balanceOf(alice), shares - maxShares, "Receiver should have correct shares remaining");
+    }
+
+    function test_Strategy_Redeem_Asset_Revert_NotWithdrawable(uint256 assets) public {
+        vm.assume(assets >= 1000 && assets <= 100_000 ether);
+        uint256 shares = depositIntoStrategy(address(weth), alice, assets);
+        assertEq(strategy.maxRedeemAsset(address(weth), alice), shares, "redeemable Assets should be equal to assets");
+        // set asset to not withdrawable
+        vm.prank(ASSET_MANAGER);
+        strategy.setAssetWithdrawable(address(weth), false);
+        assertEq(
+            strategy.maxRedeemAsset(address(weth), alice),
+            0,
+            "redeemable Assets should be 0 after asset is set to not withdrawable"
+        );
+        // assert redeem should revert
+        vm.expectRevert(abi.encodeWithSelector(IVault.ExceededMaxRedeem.selector, alice, shares, 0));
+        strategy.redeemAsset(address(weth), shares, alice, alice);
+    }
+
+    function depositIntoStrategy(address assetAddress, address depositor, uint256 amount)
+        internal
+        returns (uint256 shares)
+    {
+        IERC20 asset = IERC20(assetAddress);
+
+        uint256 beforeTotalAssets = strategy.totalAssets();
+        uint256 beforeTotalShares = strategy.totalSupply();
+        uint256 beforeStrategyBalance = asset.balanceOf(address(strategy));
+        uint256 beforeDepositorBalance = asset.balanceOf(depositor);
+        uint256 beforeDepositorShares = strategy.balanceOf(depositor);
+        uint256 beforeMaxWithdraw = strategy.maxWithdrawAsset(assetAddress, depositor);
+        assertEq(beforeMaxWithdraw, 0, "Depositor should have no max withdraw before deposit");
+
+        uint256 previewShares = strategy.previewDepositAsset(assetAddress, amount);
+
+        vm.prank(depositor);
+        asset.approve(address(strategy), amount);
+
+        // Test the deposit function
+        vm.prank(depositor);
+        shares = strategy.depositAsset(assetAddress, amount, depositor);
+
+        assertEq(previewShares, shares, "Preview shares should be equal to shares");
+
+        assertEq(
+            strategy.totalAssets(),
+            beforeTotalAssets + strategy.convertToAssets(shares),
+            "Total assets should increase by the amount deposited"
+        );
+        assertEq(
+            strategy.totalSupply(), beforeTotalShares + shares, "Total shares should increase by the amount deposited"
+        );
+
+        assertEq(
+            asset.balanceOf(address(strategy)),
+            beforeStrategyBalance + amount,
+            "Strategy should have the asset after deposit"
+        );
+        assertEq(asset.balanceOf(depositor), beforeDepositorBalance - amount, "From should not have the assets");
+        assertEq(strategy.balanceOf(depositor), beforeDepositorShares + shares, "From should have shares after deposit");
+        assertApproxEqAbs(
+            strategy.maxWithdrawAsset(address(asset), depositor),
+            beforeMaxWithdraw + amount,
+            2,
+            "Depositor should have max withdraw after deposit"
+        );
+    }
+
+    function withdrawFromStrategy(address assetAddress, address withdrawer, uint256 withdrawAmount) internal virtual {
+        IERC20 asset = IERC20(assetAddress);
+
+        // Initial balances
+        uint256 withdrawerAssetBefore = asset.balanceOf(withdrawer);
+        uint256 withdrawerSharesBefore = strategy.balanceOf(withdrawer);
+
+        // Store initial state
+        uint256 initialTotalAssets = strategy.totalAssets();
+        uint256 initialTotalSupply = strategy.totalSupply();
+
+        // Store initial strategy Asset balance
+        uint256 strategyAssetBefore = asset.balanceOf(address(strategy));
+
+        vm.startPrank(withdrawer);
+
+        // Deposit Asset to get shares
+        uint256 shares = strategy.withdrawAsset(address(asset), withdrawAmount, withdrawer, withdrawer);
+
+        vm.stopPrank();
+
+        // Check balances after deposit
+        assertEq(asset.balanceOf(withdrawer), withdrawerAssetBefore + withdrawAmount, "Asset balance incorrect");
+        assertEq(strategy.balanceOf(withdrawer), withdrawerSharesBefore - shares, "Should have burnt shares");
+
+        // Check strategy state after deposit
+        assertEq(
+            strategy.totalAssets(),
+            initialTotalAssets - withdrawAmount,
+            "Total assets should decrease by withdraw amount"
+        );
+        assertEq(strategy.totalSupply(), initialTotalSupply - shares, "Total supply should decrease by shares");
+
+        // Check that strategy Asset balance increased by deposit amount
+        assertEq(
+            asset.balanceOf(address(strategy)),
+            strategyAssetBefore - withdrawAmount,
+            "Strategy balance should decrease by withdraw amount"
+        );
+    }
+
+    function test_Strategy_Deposit_WETH(uint256 assets) external {
+        // Bound inputs to valid ranges
+        vm.assume(assets >= 1000 && assets <= 100_000 ether);
+
+        deal(address(weth), alice, assets);
+        depositIntoStrategy(address(weth), alice, assets);
+    }
+
+    function test_Strategy_Withdraw_WETH(uint256 assets) external {
+        // Bound inputs to valid ranges
+        vm.assume(assets >= 1000 && assets <= 100_000 ether);
+
+        deal(address(weth), alice, assets);
+        depositIntoStrategy(address(weth), alice, assets);
+        withdrawFromStrategy(address(weth), alice, assets);
     }
 }


### PR DESCRIPTION
Issue description: BaseStrategy withdrawal is allowed or rejected based on the Asset active flag, not on isAssetWithdrawable flag.