### PR TITLE
add withdrawAsset to BaseVault

### DIFF
--- a/src/BaseVault.sol
+++ b/src/BaseVault.sol
@@ -404,6 +404,16 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     }
 
     /**
+     * @notice Returns whether a given asset exists in the asset list of the vault.
+     * @param asset_ The address of the asset.
+     */
+    function hasAsset(address asset_) public view virtual returns (bool) {
+        AssetStorage storage assetStorage = _getAssetStorage();
+        AssetParams memory assetParams = assetStorage.assets[asset_];
+        return assetStorage.list[assetParams.index] == asset_;
+    }
+
+    /**
      * @notice Returns the function rule for a given contract address and function signature.
      * @param contractAddress The address of the contract.
      * @param funcSig The function signature.
@@ -551,6 +561,62 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     }
 
     /**
+     * @notice Withdraws a given amount of assets and transfers the equivalent amount of shares to the receiver.
+     * @dev This is a permissioned function that requires the ASSET_WITHDRAWER_ROLE.
+     * @param asset_ The address of the asset.
+     * @param assets The amount of assets to withdraw.
+     * @param receiver The address of the receiver.
+     * @param owner The address of the owner.
+     * @return shares The equivalent amount of shares.
+     */
+    function withdrawAsset(address asset_, uint256 assets, address receiver, address owner)
+        public
+        virtual
+        onlyRole(ASSET_WITHDRAWER_ROLE)
+        returns (uint256 shares)
+    {
+        (shares,) = _convertToShares(asset_, assets, Math.Rounding.Ceil);
+        if (assets > IERC20(asset_).balanceOf(address(this)) || balanceOf(owner) < shares) {
+            revert ExceededMaxWithdraw(owner, assets, IERC20(asset_).balanceOf(address(this)));
+        }
+
+        _withdrawAsset(asset_, _msgSender(), receiver, owner, assets, shares);
+    }
+
+    /**
+     * @notice Internal function to handle withdrawals for specific assets.
+     * @param asset_ The address of the asset.
+     * @param caller The address of the caller.
+     * @param receiver The address of the receiver.
+     * @param owner The address of the owner.
+     * @param assets The amount of assets to withdraw.
+     * @param shares The equivalent amount of shares.
+     */
+    function _withdrawAsset(
+        address asset_,
+        address caller,
+        address receiver,
+        address owner,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual {
+        if (!hasAsset(asset_)) revert InvalidAsset(asset_);
+
+        _subTotalAssets(_convertAssetToBase(asset_, assets));
+
+        if (caller != owner) {
+            _spendAllowance(owner, caller, shares);
+        }
+
+        // NOTE: burn shares before withdrawing the assets
+        _burn(owner, shares);
+
+        SafeERC20.safeTransfer(IERC20(asset_), receiver, assets);
+
+        emit WithdrawAsset(caller, receiver, owner, asset_, assets, shares);
+    }
+
+    /**
      * @notice Internal function to convert vault shares to the base asset.
      * @param asset_ The address of the asset.
      * @param shares The amount of shares to convert.
@@ -636,6 +702,7 @@ abstract contract BaseVault is IVault, ERC20PermitUpgradeable, AccessControlUpgr
     bytes32 public constant ASSET_MANAGER_ROLE = keccak256("ASSET_MANAGER_ROLE");
     bytes32 public constant PROCESSOR_MANAGER_ROLE = keccak256("PROCESSOR_MANAGER_ROLE");
     bytes32 public constant HOOKS_MANAGER_ROLE = keccak256("HOOKS_MANAGER_ROLE");
+    bytes32 public constant ASSET_WITHDRAWER_ROLE = keccak256("ASSET_WITHDRAWER_ROLE");
 
     /**
      * @notice Sets the provider.

--- a/src/interface/IBaseStrategy.sol
+++ b/src/interface/IBaseStrategy.sol
@@ -12,15 +12,6 @@ interface IBaseStrategy {
         bool syncWithdraw;
     }
 
-    event WithdrawAsset(
-        address indexed sender,
-        address indexed receiver,
-        address indexed owner,
-        address asset,
-        uint256 assets,
-        uint256 shares
-    );
-
     event SetHasAllocator(bool hasAllocator);
     event SetAssetWithdrawable(address asset, bool isWithdrawable);
 

--- a/src/interface/IVault.sol
+++ b/src/interface/IVault.sol
@@ -115,6 +115,15 @@ interface IVault is IERC4626 {
         uint256 baseAssets,
         uint256 shares
     );
+    event WithdrawAsset(
+        address indexed sender,
+        address indexed receiver,
+        address indexed owner,
+        address asset,
+        uint256 assets,
+        uint256 shares
+    );
+
     event SetProvider(address indexed provider);
     event SetBuffer(address indexed buffer);
     event SetAlwaysComputeTotalAssets(bool alwaysComputeTotalAssets);

--- a/src/strategy/BaseStrategy.sol
+++ b/src/strategy/BaseStrategy.sol
@@ -218,6 +218,7 @@ abstract contract BaseStrategy is BaseVault, IBaseStrategy {
     function withdrawAsset(address asset_, uint256 assets, address receiver, address owner)
         public
         virtual
+        override(BaseVault, IBaseStrategy)
         nonReentrant
         returns (uint256 shares)
     {
@@ -284,23 +285,12 @@ abstract contract BaseStrategy is BaseVault, IBaseStrategy {
         address owner,
         uint256 assets,
         uint256 shares
-    ) internal virtual onlyAllocator {
+    ) internal virtual override onlyAllocator {
         if (!_getBaseStrategyStorage().isAssetWithdrawable[asset_]) {
             revert AssetNotWithdrawable();
         }
 
-        _subTotalAssets(_convertAssetToBase(asset_, assets));
-
-        if (caller != owner) {
-            _spendAllowance(owner, caller, shares);
-        }
-
-        // NOTE: burn shares before withdrawing the assets
-        _burn(owner, shares);
-
-        SafeERC20.safeTransfer(IERC20(asset_), receiver, assets);
-
-        emit WithdrawAsset(caller, receiver, owner, asset_, assets, shares);
+        super._withdrawAsset(asset_, caller, receiver, owner, assets, shares);
     }
 
     /**

--- a/test/unit/vault/views.t.sol
+++ b/test/unit/vault/views.t.sol
@@ -12,8 +12,10 @@ import {PublicViewsVault} from "test/unit/helpers/PublicViewsVault.sol";
 import {Math} from "src/Common.sol";
 import {IERC20, IERC20Metadata} from "src/Common.sol";
 import {console} from "lib/forge-std/src/console.sol";
+import {MainnetActors} from "script/Actors.sol";
+import {MockERC20} from "test/unit/mocks/MockERC20.sol";
 
-contract VaultViewsUnitTest is Test, Etches {
+contract VaultViewsUnitTest is Test, Etches, MainnetActors {
     using Math for uint256;
 
     Vault public vaultImplementation;
@@ -79,6 +81,77 @@ contract VaultViewsUnitTest is Test, Etches {
             address asset = assets[i];
             assertEq(vault.getAsset(asset).index, i, "Bad Index");
             assertEq(vault.getAsset(asset).decimals >= 6 || vault.getAsset(asset).decimals <= 18, true, "Bad decimals");
+        }
+    }
+
+    function test_Vault_hasAsset() public view {
+        // Test that WETH (the main asset) is recognized
+        assertTrue(vault.hasAsset(MC.WETH), "WETH should be a valid asset");
+
+        // Test that STETH is recognized (if it's in the asset list)
+        assertTrue(vault.hasAsset(MC.STETH), "STETH should be a valid asset");
+
+        // Test that WBTC is recognized (if it's in the asset list)
+        assertTrue(vault.hasAsset(MC.WBTC), "WBTC should be a valid asset");
+
+        // Test that METH is recognized (if it's in the asset list)
+        assertTrue(vault.hasAsset(MC.METH), "METH should be a valid asset");
+
+        // Test that a random address is not recognized as an asset
+        address randomAddress = address(0x1234567890123456789012345678901234567890);
+        assertFalse(vault.hasAsset(randomAddress), "Random address should not be a valid asset");
+
+        // Test that zero address is not recognized as an asset
+        assertFalse(vault.hasAsset(address(0)), "Zero address should not be a valid asset");
+    }
+
+    function test_Vault_hasAsset_afterDeletion(uint256 indexToDelete) public {
+        address[] memory assets = vault.getAssets();
+        indexToDelete = bound(indexToDelete, 1, assets.length - 1);
+
+        address assetToDelete = assets[indexToDelete];
+
+        // First verify that the asset is initially valid
+        assertTrue(vault.hasAsset(assetToDelete), "Asset should initially be valid");
+
+        // Delete the asset (requires ASSET_MANAGER_ROLE)
+        vm.startPrank(ASSET_MANAGER);
+        vault.deleteAsset(indexToDelete);
+        vm.stopPrank();
+
+        // Test that the asset is no longer recognized as valid after deletion
+        assertFalse(vault.hasAsset(assetToDelete), "Asset should not be valid after deletion");
+
+        // Verify that all other assets (not the deleted one) are still valid
+        for (uint256 i = 0; i < assets.length; i++) {
+            if (assets[i] != assetToDelete) {
+                assertTrue(vault.hasAsset(assets[i]), "Other assets should still be valid after deletion");
+            }
+        }
+    }
+
+    function test_Vault_hasAsset_afterAddition() public {
+        // Create a mock ERC20 token to add as a new asset
+        MockERC20 newToken = new MockERC20("New Token", "NEW");
+        address newAsset = address(newToken);
+
+        // First verify that the new asset is not initially valid
+        assertFalse(vault.hasAsset(newAsset), "New asset should not initially be valid");
+
+        // Add the new asset (requires ASSET_MANAGER_ROLE)
+        vm.startPrank(ASSET_MANAGER);
+        vault.addAsset(newAsset, false);
+        vm.stopPrank();
+
+        // Test that the asset is now recognized as valid after addition
+        assertTrue(vault.hasAsset(newAsset), "Asset should be valid after addition");
+
+        // Verify that all existing assets are still valid
+        address[] memory existingAssets = vault.getAssets();
+        for (uint256 i = 0; i < existingAssets.length; i++) {
+            if (existingAssets[i] != newAsset) {
+                assertTrue(vault.hasAsset(existingAssets[i]), "Existing assets should still be valid after addition");
+            }
         }
     }
 

--- a/test/unit/vault/withdrawAsset.t.sol
+++ b/test/unit/vault/withdrawAsset.t.sol
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: BSD Clause-3
+pragma solidity ^0.8.24;
+
+import {Test} from "lib/forge-std/src/Test.sol";
+import {Vault} from "src/Vault.sol";
+import {TransparentUpgradeableProxy, IERC20} from "src/Common.sol";
+import {MainnetContracts as MC} from "script/Contracts.sol";
+import {Etches} from "test/unit/helpers/Etches.sol";
+import {WETH9} from "test/unit/mocks/MockWETH.sol";
+import {SetupVault} from "test/unit/helpers/SetupVault.sol";
+import {MainnetActors} from "script/Actors.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {PublicViewsVault} from "test/unit/helpers/PublicViewsVault.sol";
+import {Math} from "src/Common.sol";
+
+contract VaultWithdrawAssetUnitTest is Test, MainnetActors, Etches {
+    Vault public vaultImplementation;
+    TransparentUpgradeableProxy public vaultProxy;
+
+    Vault public vault;
+    WETH9 public weth;
+
+    address public alice = address(0x1);
+    address public bob = address(0x2);
+    address public chad = address(0x3);
+    address public withdrawerManager = address(0x4);
+
+    uint256 public constant INITIAL_BALANCE = 100_000 ether;
+
+    function setUp() public {
+        SetupVault setupVault = new SetupVault();
+        (vault, weth) = setupVault.setup();
+
+        // Give Alice some tokens
+        deal(alice, INITIAL_BALANCE);
+        weth.deposit{value: INITIAL_BALANCE}();
+        weth.transfer(alice, INITIAL_BALANCE);
+
+        // Approve vault to spend Alice's tokens
+        vm.prank(alice);
+        weth.approve(address(vault), type(uint256).max);
+
+        // Grant ASSET_WITHDRAWER_ROLE to withdrawerManager
+        vm.startPrank(ADMIN);
+        vault.grantRole(vault.ASSET_WITHDRAWER_ROLE(), withdrawerManager);
+        vm.stopPrank();
+    }
+
+    function test_withdrawAsset_DefaultAsset(uint256 depositAmount, uint256 withdrawAmount, bool callProcessAccounting)
+        public
+    {
+        // Bound deposit amount to reasonable values
+        depositAmount = bound(depositAmount, 1000, 100_000 ether); // At least 1000 wei to avoid rounding issues, up to 100k ETH
+
+        // Ensure withdraw amount is between 1 and deposit amount
+        withdrawAmount = bound(withdrawAmount, 1, depositAmount);
+
+        // Give Bob some tokens and have him deposit
+        deal(bob, INITIAL_BALANCE);
+        vm.startPrank(bob);
+        weth.deposit{value: INITIAL_BALANCE}();
+        weth.approve(address(vault), type(uint256).max);
+        uint256 sharesReceived = vault.deposit(depositAmount, bob);
+        vm.stopPrank();
+
+        // Bob sends his shares to withdrawerManager
+        vm.startPrank(bob);
+        vault.transfer(withdrawerManager, vault.balanceOf(bob));
+        vm.stopPrank();
+
+        // Record state before withdrawal
+        uint256 totalSupplyBefore = vault.totalSupply();
+        uint256 totalAssetsBefore = vault.totalAssets();
+        // Calculate expected shares to burn
+        uint256 expectedSharesToBurn = vault.previewWithdraw(withdrawAmount);
+
+        // Withdraw WETH using withdrawAsset (withdrawerManager withdraws for withdrawerManager)
+        vm.prank(withdrawerManager);
+        uint256 sharesBurned = vault.withdrawAsset(address(weth), withdrawAmount, withdrawerManager, withdrawerManager);
+
+        if (callProcessAccounting) {
+            vault.processAccounting();
+        }
+
+        // Verify the correct amount of shares were burned
+        assertEq(sharesBurned, expectedSharesToBurn, "Shares burned should match preview");
+
+        // Verify withdrawerManager's share balance decreased
+        assertEq(
+            vault.balanceOf(withdrawerManager),
+            sharesReceived - sharesBurned,
+            "WithdrawerManager's shares should be reduced by burned amount"
+        );
+
+        // Verify total supply decreased
+        assertEq(
+            vault.totalSupply(), totalSupplyBefore - sharesBurned, "Total supply should be reduced by burned amount"
+        );
+
+        // Verify total assets decreased
+        assertEq(
+            vault.totalAssets(), totalAssetsBefore - withdrawAmount, "Total assets should be reduced by withdraw amount"
+        );
+
+        // Verify withdrawerManager received the withdrawn WETH
+        assertEq(
+            weth.balanceOf(withdrawerManager),
+            withdrawAmount,
+            "WithdrawerManager should have received the withdrawn WETH"
+        );
+    }
+
+    function test_withdrawAsset_AnyAsset(
+        uint256 depositAmount,
+        uint256 withdrawAmount,
+        bool callProcessAccounting,
+        uint8 assetIndexUint8
+    ) public {
+        // Create array of assets including WETH and the 3 additional assets
+        address[] memory assets = new address[](4);
+        assets[0] = MC.WETH;
+        assets[1] = MC.STETH;
+        assets[2] = MC.WBTC;
+        assets[3] = MC.METH;
+
+        // Select one asset for testing (using modulo to ensure valid index)
+        uint256 assetIndex = assetIndexUint8 % assets.length;
+        address selectedAsset = assets[assetIndex];
+
+        depositAmount = bound(depositAmount, 1001, 100_000 * (10 ** IERC20Metadata(selectedAsset).decimals()) - 1);
+        withdrawAmount = bound(withdrawAmount, 1, depositAmount);
+
+        // Deal the selected asset to bob
+        deal(selectedAsset, bob, depositAmount);
+
+        // Bob deposits the selected asset
+        vm.startPrank(bob);
+        IERC20(selectedAsset).approve(address(vault), depositAmount);
+        uint256 sharesReceived = vault.depositAsset(selectedAsset, depositAmount, bob);
+        vm.stopPrank();
+
+        // Bob sends his shares to withdrawerManager
+        vm.startPrank(bob);
+        vault.transfer(withdrawerManager, vault.balanceOf(bob));
+        vm.stopPrank();
+
+        // Record state before withdrawal
+        uint256 totalSupplyBefore = vault.totalSupply();
+        uint256 totalAssetsBefore = vault.totalAssets();
+
+        // Calculate expected shares to burn
+        (uint256 expectedSharesToBurn,) = PublicViewsVault(payable(address(vault))).convertToSharesForAsset(
+            selectedAsset, withdrawAmount, Math.Rounding.Ceil
+        ); // vault.previewWithdraw(withdrawAmount);
+
+        // Withdraw selected asset using withdrawAsset (withdrawerManager withdraws for withdrawerManager)
+        vm.prank(withdrawerManager);
+        uint256 sharesBurned = vault.withdrawAsset(selectedAsset, withdrawAmount, withdrawerManager, withdrawerManager);
+
+        if (callProcessAccounting) {
+            vault.processAccounting();
+        }
+
+        // Verify the correct amount of shares were burned
+        assertEq(sharesBurned, expectedSharesToBurn, "Shares burned should match preview");
+
+        // Verify withdrawerManager's share balance decreased
+        assertEq(
+            vault.balanceOf(withdrawerManager),
+            sharesReceived - sharesBurned,
+            "WithdrawerManager's shares should be reduced by burned amount"
+        );
+
+        // Verify total supply decreased
+        assertEq(
+            vault.totalSupply(), totalSupplyBefore - sharesBurned, "Total supply should be reduced by burned amount"
+        );
+
+        // Verify total assets decreased
+        uint256 withdrawAmountInBase =
+            PublicViewsVault(payable(address(vault))).convertAssetToBase(selectedAsset, withdrawAmount);
+        assertApproxEqAbs(
+            vault.totalAssets(),
+            totalAssetsBefore - withdrawAmountInBase,
+            1,
+            "Total assets should be reduced by withdraw amount"
+        );
+
+        // Verify withdrawerManager received the withdrawn asset
+        assertEq(
+            IERC20(selectedAsset).balanceOf(withdrawerManager),
+            withdrawAmount,
+            "WithdrawerManager should have received the withdrawn asset"
+        );
+    }
+
+    function test_withdrawAsset_InsufficientShares() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 withdrawAmount = 500 ether;
+
+        // Give Bob some tokens and have him deposit
+        deal(bob, INITIAL_BALANCE);
+        vm.startPrank(bob);
+        weth.deposit{value: INITIAL_BALANCE}();
+        weth.approve(address(vault), type(uint256).max);
+        uint256 sharesReceived = vault.deposit(depositAmount, bob);
+        vm.stopPrank();
+
+        // Transfer vault tokens to the vault to ensure it has enough assets
+        vm.prank(bob);
+        weth.transfer(address(vault), withdrawAmount);
+
+        // Calculate required shares for withdrawal
+        (uint256 requiredShares,) = PublicViewsVault(payable(address(vault))).convertToSharesForAsset(
+            address(weth), withdrawAmount, Math.Rounding.Ceil
+        );
+
+        // Burn most of Bob's shares, leaving insufficient shares for withdrawal
+        vm.prank(bob);
+        vault.transfer(alice, sharesReceived * 2 / 3);
+
+        // Verify Bob has insufficient shares
+        assertLt(vault.balanceOf(bob), requiredShares, "Bob should have insufficient shares");
+
+        // Attempt to withdraw should revert with ExceededMaxWithdraw
+        vm.startPrank(withdrawerManager);
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "ExceededMaxWithdraw(address,uint256,uint256)",
+                bob,
+                withdrawAmount,
+                IERC20(address(weth)).balanceOf(address(vault))
+            )
+        );
+        vault.withdrawAsset(address(weth), withdrawAmount, withdrawerManager, bob);
+        vm.stopPrank();
+    }
+
+    function test_withdrawAsset_InsufficientAssets() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 withdrawAmount = 500 ether;
+
+        // Give Bob some tokens and have him deposit
+        deal(bob, INITIAL_BALANCE);
+        vm.startPrank(bob);
+        weth.deposit{value: INITIAL_BALANCE}();
+        weth.approve(address(vault), type(uint256).max);
+        vault.deposit(depositAmount, bob);
+        vm.stopPrank();
+
+        // Ensure vault has insufficient assets by not transferring any additional tokens
+        // The vault should only have the buffer amount from deposit
+
+        uint256 vaultAssetBalance = IERC20(address(weth)).balanceOf(address(vault));
+
+        // Try to withdraw more than the vault has
+        uint256 excessiveWithdrawAmount = vaultAssetBalance + 1;
+
+        // Attempt to withdraw should revert with ExceededMaxWithdraw
+        vm.startPrank(withdrawerManager);
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "ExceededMaxWithdraw(address,uint256,uint256)", bob, excessiveWithdrawAmount, vaultAssetBalance
+            )
+        );
+        vault.withdrawAsset(address(weth), excessiveWithdrawAmount, withdrawerManager, bob);
+        vm.stopPrank();
+    }
+
+    function test_withdrawAsset_WithAllowanceButNoTransfer(uint256 depositAmount, uint256 withdrawAmount) public {
+        // Bound inputs to reasonable ranges
+        depositAmount = bound(depositAmount, 1000, 10000 ether);
+        withdrawAmount = bound(withdrawAmount, 1, depositAmount);
+
+        // Give Bob some tokens and have him deposit
+        deal(bob, INITIAL_BALANCE);
+        vm.startPrank(bob);
+        weth.deposit{value: INITIAL_BALANCE}();
+        weth.approve(address(vault), type(uint256).max);
+        uint256 sharesReceived = vault.deposit(depositAmount, bob);
+
+        // Bob gives allowance to withdrawerManager for the exact amount needed
+        vault.approve(withdrawerManager, sharesReceived);
+        vm.stopPrank();
+
+        // Verify Bob still owns the shares
+        assertEq(vault.balanceOf(bob), sharesReceived, "Bob should still own all shares");
+        assertEq(vault.balanceOf(withdrawerManager), 0, "WithdrawerManager should have no shares");
+
+        // Verify allowance is set
+        assertEq(vault.allowance(bob, withdrawerManager), sharesReceived, "Allowance should be set");
+
+        uint256 initialBobBalance = weth.balanceOf(bob);
+        uint256 initialManagerBalance = weth.balanceOf(withdrawerManager);
+        uint256 initialVaultBalance = weth.balanceOf(address(vault));
+
+        // WithdrawerManager should be able to withdraw on behalf of Bob
+        vm.startPrank(withdrawerManager);
+        uint256 sharesWithdrawn = vault.withdrawAsset(address(weth), withdrawAmount, withdrawerManager, bob);
+        vm.stopPrank();
+
+        // Verify the withdrawal was successful
+        assertEq(
+            weth.balanceOf(withdrawerManager),
+            initialManagerBalance + withdrawAmount,
+            "Manager should receive the assets"
+        );
+        assertEq(weth.balanceOf(bob), initialBobBalance, "Bob's balance should remain unchanged");
+        assertEq(weth.balanceOf(address(vault)), initialVaultBalance - withdrawAmount, "Vault balance should decrease");
+        assertEq(vault.balanceOf(bob), sharesReceived - sharesWithdrawn, "Bob's shares should be burned");
+        assertEq(vault.allowance(bob, withdrawerManager), sharesReceived - sharesWithdrawn, "Allowance should be 0");
+
+        // Verify the asset was withdrawn to the correct receiver (withdrawerManager)
+        assertEq(
+            weth.balanceOf(withdrawerManager),
+            initialManagerBalance + withdrawAmount,
+            "WithdrawerManager should receive the withdrawn assets"
+        );
+    }
+}


### PR DESCRIPTION
BaseVault.withdrawAsset is a permissioned function that is used as a building block for processing queued withdrawal requests for Max vaults.

The goal there would be to be able to redeem arbitrary assets from the vault, to funnel them to withdrawers.

The role is to be assigned to a peripheral YieldNest protocol contract.

the benefit here is the following:

1.you can fulfill large redemptions faster eg. you don't need to redeem wstETH if the redeemer is ok with it.
 redeeming wstETH to service withdrawals in the max vault (Withdrawer.sol) is yield-inneficient as it affects all stakers since they all take the yield hit.

2.you protect the ynETHx yield becase wstETH in withdrawal state is not earning yield
3.you can build queue logic on top of that as a separate peripheral system
